### PR TITLE
Remove Extricate my Ship

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -74,6 +74,12 @@ Progress:
 			<displayName>Reinforced Mechanoid 2 (Continued)</displayName>
 			<steamWorkshopUrl>https://steamcommunity.com/sharedfiles/filedetails/?id=3400713047</steamWorkshopUrl>
 		</li> <!-- this has the contents of gestalt engine, and so much more. So... replaced -->
+	<!--	<li>
+			<packageId>chtech.EmS</packageId>
+			<displayName>Extricate my Ship</displayName>
+			<steamWorkshopUrl>https://steamcommunity.com/sharedfiles/filedetails/?id=3315444901</steamWorkshopUrl>
+			<downloadUrl>https://github.com/CHTechIndustries/SoS2--ExtricateMyShip</downloadUrl>
+		</li> --> <!-- commented out as, with the odesy DLC, I have no clue what Save our Ship will do -->
 		<li>
 			<packageId>tongonto.mechcaravans</packageId>
 			<displayName>Mechanoid Caravans</displayName>


### PR DESCRIPTION
as, due to the next DLC, I have no clue what will happen with Save our Ship 2, I am, for now, removeing EmS as a reqrirment